### PR TITLE
Fix connection not being put back into pool

### DIFF
--- a/sonic/client.py
+++ b/sonic/client.py
@@ -222,7 +222,8 @@ class SonicConnection:
         return self.ping()
 
     def ping(self):
-        return self._execute_command("PING")
+        res = self._execute_command("PING")
+        return res == "PONG" if self.raw else res
 
     def __create_connection(self, address):
         "Create a TCP socket connection"

--- a/sonic/client.py
+++ b/sonic/client.py
@@ -222,7 +222,7 @@ class SonicConnection:
         return self.ping()
 
     def ping(self):
-        return self._execute_command("PING") == "PONG"
+        return self._execute_command("PING")
 
     def __create_connection(self, address):
         "Create a TCP socket connection"


### PR DESCRIPTION
`self.execute_command` returns True to ping, so ping would not work when called from the client itself.

This resulted in connections never being put back into the pool, and a new connection was being used for every single push -- leading to `BlockingIOError: [Errno 35] Resource temporarily unavailable`.